### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/atmospec/centroiding.py
+++ b/python/lsst/atmospec/centroiding.py
@@ -143,19 +143,19 @@ class SingleStarCentroidTask(pipeBase.PipelineTask):
         referenceFilterName = self.config.referenceFilterOverride
         referenceFilterLabel = afwImage.FilterLabel(physical=referenceFilterName, band=referenceFilterName)
         # there's a better way of doing this with the task I think
-        originalFilterLabel = inputExp.getFilterLabel()
-        inputExp.setFilterLabel(referenceFilterLabel)
+        originalFilterLabel = inputExp.getFilter()
+        inputExp.setFilter(referenceFilterLabel)
 
         successfulFit = False
         try:
             astromResult = self.astrometry.run(sourceCat=inputSources, exposure=inputExp)
             scatter = astromResult.scatterOnSky.asArcseconds()
-            inputExp.setFilterLabel(originalFilterLabel)
+            inputExp.setFilter(originalFilterLabel)
             if scatter < 1:
                 successfulFit = True
         except (RuntimeError, TaskError):
             self.log.warn("Solver failed to run completely")
-            inputExp.setFilterLabel(originalFilterLabel)
+            inputExp.setFilter(originalFilterLabel)
 
         if successfulFit:
             target = inputExp.getMetadata()['OBJECT']

--- a/python/lsst/atmospec/processStar.py
+++ b/python/lsst/atmospec/processStar.py
@@ -666,15 +666,15 @@ class ProcessStarTask(pipeBase.PipelineTask):
         # TODO: Change this to doing this the proper way
         referenceFilterName = self.config.referenceFilterOverride
         referenceFilterLabel = afwImage.FilterLabel(physical=referenceFilterName, band=referenceFilterName)
-        originalFilterLabel = exp.getFilterLabel()  # there's a better way of doing this with the task I think
-        exp.setFilterLabel(referenceFilterLabel)
+        originalFilterLabel = exp.getFilter()  # there's a better way of doing this with the task I think
+        exp.setFilter(referenceFilterLabel)
 
         try:
             astromResult = solver.run(sourceCat=icSrc, exposure=exp)
-            exp.setFilterLabel(originalFilterLabel)
+            exp.setFilter(originalFilterLabel)
         except (RuntimeError, TaskError):
             self.log.warn("Solver failed to run completely")
-            exp.setFilterLabel(originalFilterLabel)
+            exp.setFilter(originalFilterLabel)
             return None
 
         scatter = astromResult.scatterOnSky.asArcseconds()

--- a/python/lsst/atmospec/spectraction.py
+++ b/python/lsst/atmospec/spectraction.py
@@ -180,7 +180,7 @@ class SpectractorShim():
 
     @staticmethod
     def _getFilterAndDisperserFromExp(exp):
-        filterFullName = exp.getFilterLabel().physicalLabel
+        filterFullName = exp.getFilter().physicalLabel
         if FILTER_DELIMITER not in filterFullName:
             filt = filterFullName
             grating = exp.getInfo().getMetadata()['GRATING']

--- a/python/lsst/atmospec/utils.py
+++ b/python/lsst/atmospec/utils.py
@@ -449,7 +449,7 @@ def vizierLocationForTarget(exp, target, doMotionCorrection):
 
 def isDispersedExp(exp):
     """Check if an exposure is dispersed."""
-    filterFullName = exp.getFilterLabel().physicalLabel
+    filterFullName = exp.getFilter().physicalLabel
     if FILTER_DELIMITER not in filterFullName:
         raise RuntimeError(f"Error parsing filter name {filterFullName}")
     filt, grating = filterFullName.split(FILTER_DELIMITER)


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.